### PR TITLE
Add support for custom plist files

### DIFF
--- a/AppHubDeploy.js
+++ b/AppHubDeploy.js
@@ -24,7 +24,7 @@ program
   .option('-d, --build-description <description>', 'Description of the build. Wrap in quotes if more than one word.')
   .option('-o, --open-build-url',                  'Open AppHub Builds URL after a successful build and deploy.')
   .option('-n, --build-name <name>',               'Name of the build. Wrap in quotes if more than one word.')
-  .option('-p, --plist-file',                      'Use a custom plist file for the `apphub` command.')
+  .option('-p, --plist-file <plist>',              'Use a custom plist file for the `apphub` command.')
   .option('-r, --retain-build',                    'Do not remove the build after a successful deploy. By default it will be removed.')
   .option('-t, --target <target>',                 'One of [all, debug, none] which specifies the target audience of the build. Defaults to none.')
   .option('-v, --verbose',                         'Unleashes the "Chatty Kathy" to the STDOUT - great for debugging!')

--- a/AppHubDeploy.js
+++ b/AppHubDeploy.js
@@ -24,6 +24,7 @@ program
   .option('-d, --build-description <description>', 'Description of the build. Wrap in quotes if more than one word.')
   .option('-o, --open-build-url',                  'Open AppHub Builds URL after a successful build and deploy.')
   .option('-n, --build-name <name>',               'Name of the build. Wrap in quotes if more than one word.')
+  .option('-p, --plist-file',                      'Use a custom plist file for the `apphub` command.')
   .option('-r, --retain-build',                    'Do not remove the build after a successful deploy. By default it will be removed.')
   .option('-t, --target <target>',                 'One of [all, debug, none] which specifies the target audience of the build. Defaults to none.')
   .option('-v, --verbose',                         'Unleashes the "Chatty Kathy" to the STDOUT - great for debugging!')
@@ -122,14 +123,14 @@ function readPreviouslySavedAppHubCredentials() {
 function build() {
   console.log('');
   process.stdout.write('Building... ');
-
-  buildResult = require('child_process').execSync( './node_modules/.bin/apphub build --verbose -o ' + BUILD_FILE_NAME ).toString();
+  
+  var plist = program.plistFile ? " --plist-file " + program.plistFile : ""
+  buildResult = require('child_process').execSync( './node_modules/.bin/apphub build ' + plist + ' --verbose -o ' + BUILD_FILE_NAME ).toString();
 
   if (program.verbose) {
     console.log(buildResult);
     console.log('');
   }
-
 
   process.stdout.write('Done!');
 };

--- a/AppHubDeploy.js
+++ b/AppHubDeploy.js
@@ -22,9 +22,10 @@ program
   .option('-a, --app-versions <app-versions>',     'App Versions separated by commas that are compatible with this build. Either do not use a space in between version or wrap it in quotes. Example: -a 1.0.3,1.0.4 Defaults to value in info.plist of build file.' )
   .option('-c, --configure',                       '(Re)Configure AppHub ID and Secret key.')
   .option('-d, --build-description <description>', 'Description of the build. Wrap in quotes if more than one word.')
+  .option('-e, --entry-file <entry-file>',         'The entry file for your application e.g. `index.ios.js` passed into `apphub build`.')
   .option('-o, --open-build-url',                  'Open AppHub Builds URL after a successful build and deploy.')
   .option('-n, --build-name <name>',               'Name of the build. Wrap in quotes if more than one word.')
-  .option('-p, --plist-file <plist>',              'Use a custom plist file for the `apphub` command.')
+  .option('-p, --plist-file <plist-file>',         'Use a custom plist file path in the `apphub build` command.')
   .option('-r, --retain-build',                    'Do not remove the build after a successful deploy. By default it will be removed.')
   .option('-t, --target <target>',                 'One of [all, debug, none] which specifies the target audience of the build. Defaults to none.')
   .option('-v, --verbose',                         'Unleashes the "Chatty Kathy" to the STDOUT - great for debugging!')
@@ -125,7 +126,10 @@ function build() {
   process.stdout.write('Building... ');
   
   var plist = program.plistFile ? " --plist-file " + program.plistFile : ""
-  buildResult = require('child_process').execSync( './node_modules/.bin/apphub build ' + plist + ' --verbose -o ' + BUILD_FILE_NAME ).toString();
+  var isDev = program.target == "debug" ? " --dev " : " "
+  var entryFile = program.entryFile ? " --entry-file " + program.entryFile : " "
+
+  buildResult = require('child_process').execSync( './node_modules/.bin/apphub build ' + plist + isDev + entryFile + ' --verbose -o ' + BUILD_FILE_NAME ).toString();
 
   if (program.verbose) {
     console.log(buildResult);

--- a/AppHubDeploy.js
+++ b/AppHubDeploy.js
@@ -125,11 +125,13 @@ function build() {
   console.log('');
   process.stdout.write('Building... ');
   
-  var plist = program.plistFile ? " --plist-file " + program.plistFile : ""
-  var isDev = program.target == "debug" ? " --dev " : " "
-  var entryFile = program.entryFile ? " --entry-file " + program.entryFile : " "
+  var appHubBuildOptions = ["--verbose"]
+  if (program.plistFile) { appHubBuildOptions.push("--plist-file " + program.plistFile) }
+  if (program.entryFile) { appHubBuildOptions.push("--entry-file " + program.entryFile) }
+  if (program.target == "debug") { appHubBuildOptions.push("--dev") }
+  appHubBuildOptions.push("--output-zip " + BUILD_FILE_NAME)
 
-  buildResult = require('child_process').execSync( './node_modules/.bin/apphub build ' + plist + isDev + entryFile + ' --verbose -o ' + BUILD_FILE_NAME ).toString();
+  buildResult = require('child_process').execSync( './node_modules/.bin/apphub build ' + appHubBuildOptions.join(" ") ).toString();
 
   if (program.verbose) {
     console.log(buildResult);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apphubdeploy",
-  "version": "0.0.8",
+  "version": "0.0.7",
   "description": "Build and Deploy to AppHub in one fell swoop.",
   "bin": {
     "apphubdeploy": "./AppHubDeploy.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apphubdeploy",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Build and Deploy to AppHub in one fell swoop.",
   "bin": {
     "apphubdeploy": "./AppHubDeploy.js"


### PR DESCRIPTION
Hey there, nice library, I'm adding it to our React Native app - we have a [pretty custom setup](http://artsy.github.io/blog/2016/08/24/On-Emission/), and so need to use a custom Plist in the deployment process. 

Does this feel right? I assume the build version numbering comes later in the process as that's down in deployment and can figure it out without needing to pass it through again later
